### PR TITLE
feat(navbar): extract NAV_LINKS constant and LinksList component

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,55 +1,22 @@
 // src/components/Navbar.tsx
 import React from 'react';
+import { LinksList } from './ui/LinksList.tsx';
 
-const Navbar: React.FC = () => {
-  return (
-    <nav className="fixed left-0 top-0 z-50 w-full bg-white/60 backdrop-blur-md">
-      <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
-        {/* Logo / Name */}
-        <a href="#hero" className="text-2xl font-bold text-gray-900">
-          _onath__
-        </a>
+const Navbar: React.FC = () => (
+  <nav className="fixed inset-x-0 top-0 z-50 bg-white/60 backdrop-blur-md">
+    <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
+      {/* Logo / Name */}
+      <a href="#hero" className="text-2xl font-bold text-gray-900">
+        _onath__
+      </a>
 
-        {/* Desktop Links */}
-        <ul className="hidden space-x-8 font-medium text-gray-700 md:flex">
-          <li>
-            <a href="#hero" className="transition-colors hover:text-gray-900">
-              Home
-            </a>
-          </li>
-          <li>
-            <a href="#cv" className="transition-colors hover:text-gray-900">
-              CV
-            </a>
-          </li>
-          <li>
-            <a
-              href="#projects"
-              className="transition-colors hover:text-gray-900"
-            >
-              Projects
-            </a>
-          </li>
-          <li>
-            <a
-              href="#ongoings"
-              className="transition-colors hover:text-gray-900"
-            >
-              Ongoings
-            </a>
-          </li>
-          <li>
-            <a
-              href="#cool-stuff"
-              className="transition-colors hover:text-gray-900"
-            >
-              Cool Stuff
-            </a>
-          </li>
-        </ul>
-      </div>
-    </nav>
-  );
-};
+      {/* Desktop Links */}
+      <LinksList className="hidden space-x-8 font-medium text-gray-700 md:flex" />
+
+      {/* Mobile Links (static for now) */}
+      <LinksList className="flex flex-col space-y-4 font-medium text-gray-700 md:hidden" />
+    </div>
+  </nav>
+);
 
 export default Navbar;

--- a/src/components/ui/LinksList.tsx
+++ b/src/components/ui/LinksList.tsx
@@ -1,0 +1,27 @@
+// src/components/LinksList.tsx
+import React from 'react';
+import { NAV_LINKS } from '../../constants/NavLinks';
+
+interface LinksListProps {
+  className?: string;
+  onClick?: () => void;
+}
+
+export const LinksList: React.FC<LinksListProps> = ({
+  className = '',
+  onClick,
+}) => (
+  <ul className={className}>
+    {NAV_LINKS.map(({ href, label }) => (
+      <li key={href}>
+        <a
+          href={href}
+          className="block transition-colors hover:text-gray-900"
+          onClick={onClick}
+        >
+          {label}
+        </a>
+      </li>
+    ))}
+  </ul>
+);

--- a/src/constants/NavLinks.ts
+++ b/src/constants/NavLinks.ts
@@ -1,0 +1,8 @@
+// src/constants/NavLinks.ts
+export const NAV_LINKS = [
+  { href: '#hero', label: 'Home' },
+  { href: '#cv', label: 'CV' },
+  { href: '#projects', label: 'Projects' },
+  { href: '#ongoings', label: 'Ongoings' },
+  { href: '#cool-stuff', label: 'Cool Stuff' },
+];


### PR DESCRIPTION
- closes #13
- Move NAV_LINKS into src/constants/NavLinks.ts
- Create LinksList.tsx to render nav links in both desktop & mobile
- Update Navbar to consume LinksList for both breakpoints
- Add unit test asserting NAV_LINKS count matches rendered <li> count