### PR TITLE
feat(navbar): add mobile hamburger toggle and dropdown menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@fontsource/inter": "^5.2.6",
         "@fontsource/montserrat": "^5.2.6",
         "framer-motion": "^12.18.1",
+        "lucide-react": "^0.536.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -5338,6 +5339,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.536.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.536.0.tgz",
+      "integrity": "sha512-2PgvNa9v+qz4Jt/ni8vPLt4jwoFybXHuubQT8fv4iCW5TjDxkbZjNZZHa485ad73NSEn/jdsEtU57eE1g+ma8A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@fontsource/inter": "^5.2.6",
     "@fontsource/montserrat": "^5.2.6",
     "framer-motion": "^12.18.1",
+    "lucide-react": "^0.536.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,22 +1,54 @@
 // src/components/Navbar.tsx
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { Menu, X } from 'lucide-react';
 import { LinksList } from './ui/LinksList.tsx';
 
-const Navbar: React.FC = () => (
-  <nav className="fixed inset-x-0 top-0 z-50 bg-white/60 backdrop-blur-md">
-    <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
-      {/* Logo / Name */}
-      <a href="#hero" className="text-2xl font-bold text-gray-900">
-        _onath__
-      </a>
+const Navbar: React.FC = () => {
+  const [isOpen, setIsOpen] = useState(false);
 
-      {/* Desktop Links */}
-      <LinksList className="hidden space-x-8 font-medium text-gray-700 md:flex" />
+  // prevent body scroll when mobile menu is open
+  useEffect(() => {
+    document.body.classList.toggle('overflow-hidden', isOpen);
+    return () => document.body.classList.remove('overflow-hidden');
+  }, [isOpen]);
 
-      {/* Mobile Links (static for now) */}
-      <LinksList className="flex flex-col space-y-4 font-medium text-gray-700 md:hidden" />
-    </div>
-  </nav>
-);
+  return (
+    <nav className="fixed inset-x-0 top-0 z-50 bg-white/60 backdrop-blur-md">
+      <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
+        {/* Logo / Name */}
+        <a href="#hero" className="text-2xl font-bold text-gray-900">
+          _onath__
+        </a>
+
+        {/* Desktop Links */}
+        <LinksList className="hidden space-x-8 font-medium text-gray-700 md:flex" />
+
+        {/* Hamburger toggle (below md) */}
+        <button
+          className="text-gray-700 hover:text-gray-900 focus:outline-none md:hidden"
+          aria-label={isOpen ? 'Close menu' : 'Open menu'}
+          aria-expanded={isOpen}
+          aria-controls="mobile-menu"
+          onClick={() => setIsOpen((prev) => !prev)}
+        >
+          {isOpen ? <X size={24} /> : <Menu size={24} />}
+        </button>
+      </div>
+
+      {/* Mobile dropdown menu */}
+      {isOpen && (
+        <div
+          id="mobile-menu"
+          className="absolute inset-x-0 top-full bg-white/90 p-6 backdrop-blur-md md:hidden"
+        >
+          <LinksList
+            className="flex flex-col space-y-4 font-medium text-gray-700"
+            onClick={() => setIsOpen(false)}
+          />
+        </div>
+      )}
+    </nav>
+  );
+};
 
 export default Navbar;


### PR DESCRIPTION
- closes #12
- Display hamburger button below `md` breakpoint
- Toggle `isOpen` state to show/hide mobile dropdown
- Render `LinksList` in an absolutely positioned dropdown (`#mobile-menu`)
- Close dropdown on link click and lock body scroll when open