### PR TITLE
feat(bg): token-based blobs, deterministic parallax, density control; keep wrapper positioning

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,11 @@ function App() {
       {/* parallax background shapes (deferred) */}
       <Suspense fallback={null}>
         <div className="pointer-events-none absolute inset-0 z-10 overflow-hidden">
-          <BackgroundShapes />
+          <BackgroundShapes
+            density="lush"
+            speed={10}
+            amplitude={{ x: 12, y: 30 }}
+          />
         </div>
       </Suspense>
 


### PR DESCRIPTION
This PR refactors the background blobs/parallax layer to preserve the original “drift in/out of viewport” feel while making it theme-aware, smoother, and easier to tune.
- Keeps the positioned/clipping wrapper in App.tsx (absolute inset-0 … overflow-hidden).
- BackgroundShapes is now a static canvas that only handles motion; no self-positioning.
- Theme tokens drive blob colors (auto light/dark) via color-mix().
- Deterministic blob layout per mount + spring smoothing.
- Reduced-motion users get a non-moving background.
- Adds density prop ('sparse' | 'normal' | 'lush') with count override.