### PR TITLE
Story Banner Polish — alternating layouts, tokenized type/colors, tone-driven art

### DIFF
--- a/docs/DesingManifest.md
+++ b/docs/DesingManifest.md
@@ -1,20 +1,21 @@
 # Tech & Health Color Palette Design Document
 
 ## Overview
+
 This document presents a six-tone color palette optimized for a technology-driven healthcare environment. All primary tones are designed to work with `text-offWhite` (`#F8F9FA`) for high legibility and accessibility. Each primary color is paired with its complementary accent to provide visual harmony and emphasis for UI components such as buttons, badges, alerts, and charts.
 
 ---
 
 ## Color Palette
 
-| Name           | Tailwind Class     | Hex      | Complementary Hex | Complementary Use                                   |
-| -------------- | ------------------ | -------- | ----------------- | --------------------------------------------------- |
-| **Tech Blue**  | `bg-blue-600`      | `#2563EB`| `#DA9C14`         | Golden accent for highlights, chart bars, hover states |
-| **Human Teal** | `bg-teal-500`      | `#14B8A6`| `#EB4759`         | Soft coral for badges, links, interactive elements   |
-| **Vital Green**| `bg-emerald-500`   | `#10B981`| `#EF467E`         | Muted magenta overlays or progress indicators       |
-| **Soft Slate** | `bg-slate-400`     | `#64748B`| `#9B8B74`         | Warm taupe accents for borders, dividers            |
-| **Care Purple**| `bg-purple-400`    | `#A78BFA`| `#587405`         | Olive-green call-outs for status chips              |
-| **Alert Orange**| `bg-orange-400`   | `#FB923C`| `#046DC3`         | Rich blue for critical alerts, badges, icons        |
+| Name             | Tailwind Class   | Hex       | Complementary Hex | Complementary Use                                      |
+| ---------------- | ---------------- | --------- | ----------------- | ------------------------------------------------------ |
+| **Tech Blue**    | `bg-blue-600`    | `#2563EB` | `#DA9C14`         | Golden accent for highlights, chart bars, hover states |
+| **Human Teal**   | `bg-teal-500`    | `#14B8A6` | `#EB4759`         | Soft coral for badges, links, interactive elements     |
+| **Vital Green**  | `bg-emerald-500` | `#10B981` | `#EF467E`         | Muted magenta overlays or progress indicators          |
+| **Soft Slate**   | `bg-slate-400`   | `#64748B` | `#9B8B74`         | Warm taupe accents for borders, dividers               |
+| **Care Purple**  | `bg-purple-400`  | `#A78BFA` | `#587405`         | Olive-green call-outs for status chips                 |
+| **Alert Orange** | `bg-orange-400`  | `#FB923C` | `#046DC3`         | Rich blue for critical alerts, badges, icons           |
 
 ---
 
@@ -29,12 +30,15 @@ This document presents a six-tone color palette optimized for a technology-drive
    - Use **complementary hues** sparingly to draw attention: badges, notification dots, chart highlights.
 
 3. **Examples**
+
    ```html
    <!-- Primary Button -->
-   <button class="bg-techBlue text-offWhite py-2 px-4 rounded">Start Session</button>
+   <button class="bg-techBlue text-offWhite rounded px-4 py-2">
+     Start Session
+   </button>
 
    <!-- Accent Badge -->
-   <span class="bg-[#DA9C14] text-offWhite px-2 py-1 rounded-full">New</span>
+   <span class="text-offWhite rounded-full bg-[#DA9C14] px-2 py-1">New</span>
    ```
 
 4. **Consistency**
@@ -47,33 +51,34 @@ This document presents a six-tone color palette optimized for a technology-drive
 ---
 
 ## Tailwind Configuration Snippet
+
 ```js
 // tailwind.config.js
 module.exports = {
   theme: {
     extend: {
       colors: {
-        techBlue:   '#2563EB',
-        humanTeal:  '#14B8A6',
+        techBlue: '#2563EB',
+        humanTeal: '#14B8A6',
         vitalGreen: '#10B981',
-        softSlate:  '#64748B',
+        softSlate: '#64748B',
         carePurple: '#A78BFA',
-        alertOrange:'#FB923C',
+        alertOrange: '#FB923C',
         accentGold: '#DA9C14',
-        accentCoral:'#EB4759',
-        accentMagenta:'#EF467E',
-        accentTaupe:'#9B8B74',
-        accentOlive:'#587405',
+        accentCoral: '#EB4759',
+        accentMagenta: '#EF467E',
+        accentTaupe: '#9B8B74',
+        accentOlive: '#587405',
         accentBlue: '#046DC3',
-        offWhite:   '#F8F9FA',
-      }
-    }
-  }
-}
+        offWhite: '#F8F9FA',
+      },
+    },
+  },
+};
 ```
 
 ---
 
 ## Conclusion
-This palette balances the trustworthiness and clarity of tech-focused blues and teals with the warmth and vitality of greens, purples, and oranges. Complementary accents provide flexible highlights without compromising accessibility and cohesion.
 
+This palette balances the trustworthiness and clarity of tech-focused blues and teals with the warmth and vitality of greens, purples, and oranges. Complementary accents provide flexible highlights without compromising accessibility and cohesion.

--- a/docs/DesingManifest.md
+++ b/docs/DesingManifest.md
@@ -1,0 +1,79 @@
+# Tech & Health Color Palette Design Document
+
+## Overview
+This document presents a six-tone color palette optimized for a technology-driven healthcare environment. All primary tones are designed to work with `text-offWhite` (`#F8F9FA`) for high legibility and accessibility. Each primary color is paired with its complementary accent to provide visual harmony and emphasis for UI components such as buttons, badges, alerts, and charts.
+
+---
+
+## Color Palette
+
+| Name           | Tailwind Class     | Hex      | Complementary Hex | Complementary Use                                   |
+| -------------- | ------------------ | -------- | ----------------- | --------------------------------------------------- |
+| **Tech Blue**  | `bg-blue-600`      | `#2563EB`| `#DA9C14`         | Golden accent for highlights, chart bars, hover states |
+| **Human Teal** | `bg-teal-500`      | `#14B8A6`| `#EB4759`         | Soft coral for badges, links, interactive elements   |
+| **Vital Green**| `bg-emerald-500`   | `#10B981`| `#EF467E`         | Muted magenta overlays or progress indicators       |
+| **Soft Slate** | `bg-slate-400`     | `#64748B`| `#9B8B74`         | Warm taupe accents for borders, dividers            |
+| **Care Purple**| `bg-purple-400`    | `#A78BFA`| `#587405`         | Olive-green call-outs for status chips              |
+| **Alert Orange**| `bg-orange-400`   | `#FB923C`| `#046DC3`         | Rich blue for critical alerts, badges, icons        |
+
+---
+
+## Usage Guidelines
+
+1. **Accessibility & Contrast**
+   - All primary background colors meet WCAG AA standards for `#F8F9FA` (`text-offWhite`).
+   - Use contrast-checking tools when adjusting shades.
+
+2. **Primary vs. Accent**
+   - Use **primary colors** (`techBlue`, `humanTeal`, etc.) for button backgrounds, cards, section headers.
+   - Use **complementary hues** sparingly to draw attention: badges, notification dots, chart highlights.
+
+3. **Examples**
+   ```html
+   <!-- Primary Button -->
+   <button class="bg-techBlue text-offWhite py-2 px-4 rounded">Start Session</button>
+
+   <!-- Accent Badge -->
+   <span class="bg-[#DA9C14] text-offWhite px-2 py-1 rounded-full">New</span>
+   ```
+
+4. **Consistency**
+   - Define all colors in `tailwind.config.js` under `extend.colors`.
+   - Create helper classes if needed, e.g., `.text-accent-coral` or `.bg-accent-gold`.
+
+5. **Brand Adaptation**
+   - These base tones can be tweaked ±100 shade levels (e.g., `blue-700` for darker emphasis) to fit your brand’s existing hues.
+
+---
+
+## Tailwind Configuration Snippet
+```js
+// tailwind.config.js
+module.exports = {
+  theme: {
+    extend: {
+      colors: {
+        techBlue:   '#2563EB',
+        humanTeal:  '#14B8A6',
+        vitalGreen: '#10B981',
+        softSlate:  '#64748B',
+        carePurple: '#A78BFA',
+        alertOrange:'#FB923C',
+        accentGold: '#DA9C14',
+        accentCoral:'#EB4759',
+        accentMagenta:'#EF467E',
+        accentTaupe:'#9B8B74',
+        accentOlive:'#587405',
+        accentBlue: '#046DC3',
+        offWhite:   '#F8F9FA',
+      }
+    }
+  }
+}
+```
+
+---
+
+## Conclusion
+This palette balances the trustworthiness and clarity of tech-focused blues and teals with the warmth and vitality of greens, purples, and oranges. Complementary accents provide flexible highlights without compromising accessibility and cohesion.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
         "vite": "^6.3.5",
+        "vite-plugin-svgr": "^4.3.0",
         "vitest": "^3.2.4"
       },
       "engines": {
@@ -1322,6 +1323,49 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.2.0.tgz",
+      "integrity": "sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.46.2.tgz",
@@ -1601,6 +1645,244 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
+      "integrity": "sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-plugin-remove-jsx-attribute": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-8.0.0.tgz",
+      "integrity": "sha512-BcCkm/STipKvbCl6b7QFrMh/vx00vIP63k2eM66MfHJzPr6O2U0jYEViXkHJWqXqQYjdeA9cuCl5KWmlwjDvbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-plugin-remove-jsx-empty-expression": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-8.0.0.tgz",
+      "integrity": "sha512-5BcGCBfBxB5+XSDSWnhTThfI9jcO5f0Ai2V24gZpG+wXF14BzwxxdDb4g6trdOux0rhibGs385BeFMSmxtS3uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-plugin-replace-jsx-attribute-value": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-8.0.0.tgz",
+      "integrity": "sha512-KVQ+PtIjb1BuYT3ht8M5KbzWBhdAjjUPdlMtpuw/VjT8coTrItWX6Qafl9+ji831JaJcu6PJNKCV0bp01lBNzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-plugin-svg-dynamic-title": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-8.0.0.tgz",
+      "integrity": "sha512-omNiKqwjNmOQJ2v6ge4SErBbkooV2aAWwaPFs2vUY7p7GhVkzRkJ00kILXQvRhA6miHnNpXv7MRnnSjdRjK8og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-plugin-svg-em-dimensions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-8.0.0.tgz",
+      "integrity": "sha512-mURHYnu6Iw3UBTbhGwE/vsngtCIbHE43xCRK7kCw4t01xyGqb2Pd+WXekRRoFOBIY29ZoOhUCTEweDMdrjfi9g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-plugin-transform-react-native-svg": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-8.1.0.tgz",
+      "integrity": "sha512-Tx8T58CHo+7nwJ+EhUwx3LfdNSG9R2OKfaIXXs5soiy5HtgoAEkDay9LIimLOcG8dJQH1wPZp/cnAv6S9CrR1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-plugin-transform-svg-component": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-8.0.0.tgz",
+      "integrity": "sha512-DFx8xa3cZXTdb/k3kfPeaixecQLgKh5NVBMwD0AQxOzcZawK4oo1Jh9LbrcACUivsCA7TLG8eeWgrDXjTMhRmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/babel-preset": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-8.1.0.tgz",
+      "integrity": "sha512-7EYDbHE7MxHpv4sxvnVPngw5fuR6pw79SkcrILHJ/iMpuKySNCl5W1qcwPEpU+LgyRXOaAFgH0KhwD18wwg6ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@svgr/babel-plugin-add-jsx-attribute": "8.0.0",
+        "@svgr/babel-plugin-remove-jsx-attribute": "8.0.0",
+        "@svgr/babel-plugin-remove-jsx-empty-expression": "8.0.0",
+        "@svgr/babel-plugin-replace-jsx-attribute-value": "8.0.0",
+        "@svgr/babel-plugin-svg-dynamic-title": "8.0.0",
+        "@svgr/babel-plugin-svg-em-dimensions": "8.0.0",
+        "@svgr/babel-plugin-transform-react-native-svg": "8.1.0",
+        "@svgr/babel-plugin-transform-svg-component": "8.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@svgr/core": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
+      "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.21.3",
+        "@svgr/babel-preset": "8.1.0",
+        "camelcase": "^6.2.0",
+        "cosmiconfig": "^8.1.3",
+        "snake-case": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/@svgr/hast-util-to-babel-ast": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-8.0.0.tgz",
+      "integrity": "sha512-EbDKwO9GpfWP4jN9sGdYwPBU0kdomaPIL2Eu4YwmgP+sJeXT+L7bMwJUBnhzfH8Q2qMBqZ4fJwpCyYsAN3mt2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.21.3",
+        "entities": "^4.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/@svgr/hast-util-to-babel-ast/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@svgr/plugin-jsx": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-8.1.0.tgz",
+      "integrity": "sha512-0xiIyBsLlr8quN+WyuxooNW9RJ0Dpr8uOnH/xrCVO8GLUcwHISwj1AG0k+LFzteTkAA0GbX0kj9q6Dk70PTiPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.21.3",
+        "@svgr/babel-preset": "8.1.0",
+        "@svgr/hast-util-to-babel-ast": "8.0.0",
+        "svg-parser": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      },
+      "peerDependencies": {
+        "@svgr/core": "*"
+      }
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.11",
@@ -2793,6 +3075,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001731",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
@@ -2960,6 +3255,33 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3166,6 +3488,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3233,6 +3566,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-abstract": {
@@ -4454,6 +4797,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-async-function": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
@@ -4969,6 +5319,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -5288,6 +5645,13 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lint-staged": {
       "version": "16.1.4",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.1.4.tgz",
@@ -5455,6 +5819,16 @@
       "integrity": "sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -5673,6 +6047,17 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.19",
@@ -5903,6 +6288,25 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -5942,6 +6346,16 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -6703,6 +7117,17 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6941,6 +7366,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/svg-parser": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
+      "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
@@ -7446,6 +7878,21 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-plugin-svgr": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-4.3.0.tgz",
+      "integrity": "sha512-Jy9qLB2/PyWklpYy0xk0UU3TlU0t2UMpJXZvf+hWII1lAmRHrOUKi11Uw8N3rxoNk7atZNYO3pR3vI1f7oi+6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.3",
+        "@svgr/core": "^8.1.0",
+        "@svgr/plugin-jsx": "^8.1.0"
+      },
+      "peerDependencies": {
+        "vite": ">=2.6.0"
       }
     },
     "node_modules/vite/node_modules/fdir": {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   "dependencies": {
     "@fontsource/inter": "^5.2.6",
     "@fontsource/montserrat": "^5.2.6",
+    "clsx": "^2.1.1",
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.536.0",
-    "clsx": "^2.1.1",
     "motion": "^12.23.12",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
@@ -51,6 +51,7 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5",
+    "vite-plugin-svgr": "^4.3.0",
     "vitest": "^3.2.4"
   },
   "prettier": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import ProjectsSection from './components/ProjectSection';
 import OngoingsSection from './components/OngoingSection';
 import Footer from './components/Footer';
 import WipPlaceholder from './components/WipPlaceholder';
+import ExamplePage from './components/Storybanner';
 
 // Lazy-load the background shapes to defer non-critical paint
 const BackgroundShapes = React.lazy(
@@ -36,6 +37,7 @@ function App() {
       <Hero />
 
       <main>
+        <ExamplePage />
         <ProjectsSection />
         <OngoingsSection />
       </main>

--- a/src/assets/flow/broad-undulation.svg
+++ b/src/assets/flow/broad-undulation.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 200 400" xmlns="http://www.w3.org/2000/svg" fill="none"
+     stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="
+    M20,400
+    C 50,320  180,360  180,300
+    C 190,40   20,60    100,0
+  "/>
+</svg>

--- a/src/assets/flow/double-s-curve.svg
+++ b/src/assets/flow/double-s-curve.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 200 400" xmlns="http://www.w3.org/2000/svg" fill="none"
+     stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round">
+  <path d="
+    M180,400
+    C20,160 50,160 100,120
+    S20,80 35,40
+    S35,0 35,0
+  "/>
+</svg>

--- a/src/assets/flow/gentle-wave.svg
+++ b/src/assets/flow/gentle-wave.svg
@@ -1,0 +1,17 @@
+<svg viewBox="0 0 200 400"
+     xmlns="http://www.w3.org/2000/svg"
+     fill="none"
+     stroke="currentColor"
+     stroke-width="2"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+>
+    <path d="
+      M10,0
+      C40,130 80,145 110,120
+      S140,190 170,110
+      S200,130 140,300
+      S200,100 15,400
+
+    "/>
+</svg>

--- a/src/assets/flow/lofty-spiral.svg
+++ b/src/assets/flow/lofty-spiral.svg
@@ -1,0 +1,12 @@
+<svg viewBox="00 0 200 400" xmlns="http://www.w3.org/2000/svg" fill="none"
+     stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="
+    M20,400
+    S200,350  20,150
+
+    C60,140 120,150 80,100
+    S160,80 120,40
+    S180,20 150,10
+    S150,0  160,0
+  "/>
+</svg>

--- a/src/assets/flow/loop-rise.svg
+++ b/src/assets/flow/loop-rise.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 200 400" xmlns="http://www.w3.org/2000/svg" fill="none"
+     stroke="currentColor" stroke-width="2" stroke-linecap="round">
+  <path d="M150,400 
+           C100,140 100,140 40,200 
+           C180,100 80,80 40,0" />
+</svg>

--- a/src/assets/flow/single-loop.svg
+++ b/src/assets/flow/single-loop.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 200 400" xmlns="http://www.w3.org/2000/svg" fill="none"
+     stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round">
+  <path d="
+    M35,400
+    C20,150 100,150 135,100
+    C20,150 150,100 135,200
+    S35,0 180,0
+  "/>
+</svg>

--- a/src/assets/flow/squigle-one.svg
+++ b/src/assets/flow/squigle-one.svg
@@ -1,0 +1,8 @@
+<svg viewBox="00 0 200 400" xmlns="http://www.w3.org/2000/svg" fill="none"
+     stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="
+    M00,400
+    C60,160 120,160 10,140, 200,0 10,10 100,10
+    C60,80  140,80  198,0
+  "/>
+</svg>

--- a/src/assets/flow/triple-loop-spiral.svg
+++ b/src/assets/flow/triple-loop-spiral.svg
@@ -1,0 +1,10 @@
+<svg viewBox="0 0 200 400" xmlns="http://www.w3.org/2000/svg" fill="none"
+     stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round">
+  <path d="
+    M35,400
+    C25,170 145,170 35,150
+    C15,170 145,70 150,250
+    S25,40 35,110
+    S15,90 35,00
+  "/>
+</svg>

--- a/src/assets/flow/winding-meander.svg
+++ b/src/assets/flow/winding-meander.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 200 400" xmlns="http://www.w3.org/2000/svg" fill="none"
+     stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round">
+  <path d="
+    M135,400
+    C10,170 60,170 35,140
+    S10,100 35,80
+    S10,40 135,0
+  "/>
+</svg>

--- a/src/assets/sample.svg
+++ b/src/assets/sample.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 70 200" xmlns="http://www.w3.org/2000/svg" fill="none"
+     stroke="currentColor" stroke-width="1" stroke-linecap="round">
+  <path d="M35,200 
+           C20,160 50,160 35,140 
+           C20,120 50,120 35,100 
+           L35,0" />
+</svg>

--- a/src/assets/sample.svg
+++ b/src/assets/sample.svg
@@ -1,7 +1,0 @@
-<svg viewBox="0 0 70 200" xmlns="http://www.w3.org/2000/svg" fill="none"
-     stroke="currentColor" stroke-width="1" stroke-linecap="round">
-  <path d="M35,200 
-           C20,160 50,160 35,140 
-           C20,120 50,120 35,100 
-           L35,0" />
-</svg>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,13 +1,12 @@
 // src/components/Navbar.tsx
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Menu, X } from 'lucide-react';
-import { LinksList } from './ui/LinksList.tsx';
+import { LinksList } from './ui/LinksList';
+import { useActiveSection } from '../hooks/useActiveSection';
 
 let DevThemeToggle: React.ComponentType | null = null;
-
 if (import.meta.env.DEV) {
-  // only imported in dev builds
-  DevThemeToggle = React.lazy(() => import('./ThemeToggle.tsx'));
+  DevThemeToggle = React.lazy(() => import('./ThemeToggle'));
 }
 
 const Navbar: React.FC = () => {
@@ -19,23 +18,38 @@ const Navbar: React.FC = () => {
     return () => document.body.classList.remove('overflow-hidden');
   }, [isOpen]);
 
+  // sections you want to spy (ensure your sections have these ids)
+  const sectionIds = useMemo(
+    () =>
+      ['hero', 'people', 'mission', 'vision', 'projects', 'ongoings'] as const,
+    []
+  );
+  const activeId = useActiveSection(sectionIds);
+
   return (
     <nav className="navbar-glass fixed inset-x-0 top-0 z-50">
       <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
         {/* Logo / Name */}
-        <a href="#hero" className="text-2xl font-bold text-gray-900">
+        <a href="#hero" className="text-ink text-2xl font-bold">
           _onath__
         </a>
+
+        {/* Dev-only theme toggle */}
         {DevThemeToggle && (
           <React.Suspense fallback={null}>
             <DevThemeToggle />
           </React.Suspense>
-        )}{' '}
+        )}
+
         {/* Desktop Links */}
-        <LinksList className="hidden space-x-8 font-medium text-gray-700 md:flex" />
+        <LinksList
+          activeId={activeId}
+          className="hidden items-center gap-8 font-medium md:flex"
+        />
+
         {/* Hamburger toggle (below md) */}
         <button
-          className="text-gray-700 hover:text-gray-900 focus:outline-none md:hidden"
+          className="text-muted hover:text-ink focus-ring md:hidden"
           aria-label={isOpen ? 'Close menu' : 'Open menu'}
           aria-expanded={isOpen}
           aria-controls="mobile-menu"
@@ -52,7 +66,8 @@ const Navbar: React.FC = () => {
           className="relative inset-x-0 top-full p-6 md:hidden"
         >
           <LinksList
-            className="flex flex-col space-y-4 font-medium text-gray-700"
+            activeId={activeId}
+            className="flex flex-col space-y-4 font-medium"
             onClick={() => setIsOpen(false)}
           />
         </div>

--- a/src/components/Storybanner.tsx
+++ b/src/components/Storybanner.tsx
@@ -10,13 +10,34 @@ const ExamplePage: React.FC = () => {
   return (
     <>
       <SubsectionBanner
-        textSide="left"
-        bgColor="bg-surface-data"
+        textSide="right"
+        tone="people"
         height="h-[90svh]"
         art={
           <ArtSection
             svg={SvgA}
-            className="text-primary"
+            mobileRotateAndStretch
+            preserveAspectRatio="xMidYMid meet"
+            unsetWidthHeight
+            strokeWidth="3px"
+          />
+        }
+        ariaLabel="Our People"
+      >
+        <StoryTextElement
+          title="Our People"
+          paragraph="We have great People. They are:"
+          bullets={['Strong', 'Beautiful', 'Kind']}
+          badges={['Social Engagement', 'Team-Work', 'Love']}
+        />
+      </SubsectionBanner>
+      <SubsectionBanner
+        textSide="left"
+        tone="health"
+        height="h-[90svh]"
+        art={
+          <ArtSection
+            svg={SvgA}
             mobileRotateAndStretch
             preserveAspectRatio="xMidYMid meet"
             unsetWidthHeight
@@ -39,12 +60,11 @@ const ExamplePage: React.FC = () => {
 
       <SubsectionBanner
         textSide="right"
-        bgColor="bg-surface-health"
+        tone="data"
         height="h-[90svh]"
         art={
           <ArtSection
             svg={SvgB}
-            className="text-people"
             mobileRotateAndStretch
             preserveAspectRatio="xMidYMid meet"
             unsetWidthHeight

--- a/src/components/Storybanner.tsx
+++ b/src/components/Storybanner.tsx
@@ -1,4 +1,3 @@
-// ExamplePage.tsx
 import * as React from 'react';
 import { useShuffledSvgs } from '../hooks/useShuffledSvgs';
 import { SubsectionBanner } from './ui/SubsectionBanner';
@@ -11,44 +10,46 @@ const ExamplePage: React.FC = () => {
   return (
     <>
       <SubsectionBanner
-        textSide="left" // desktop: text left, art right
-        bgColor="bg-indigo-50"
-        height="h-[100svh]"
+        textSide="left"
+        bgColor="bg-surface-data"
+        height="h-[90svh]"
         art={
           <ArtSection
             svg={SvgA}
-            className="text-yellow-500"
-            mobileRotateAndStretch // rotate + stretch on mobile
+            className="text-primary"
+            mobileRotateAndStretch
             preserveAspectRatio="xMidYMid meet"
             unsetWidthHeight
           />
         }
+        ariaLabel="Our mission"
       >
         <StoryTextElement
           title="Our Mission"
           paragraph="We build amazing experiences that scale across devices."
           bullets={[
-            'Responsive Design',
-            'High Performance',
-            'Scalable Architecture',
+            'Responsive design',
+            'High performance',
+            'Scalable architecture',
           ]}
           badges={['Responsive', 'Scalable', 'Modern']}
         />
       </SubsectionBanner>
 
       <SubsectionBanner
-        textSide="right" // desktop: text right, art left
-        bgColor="bg-emerald-50"
-        height="h-[100svh]"
+        textSide="right"
+        bgColor="bg-surface-health"
+        height="h-[90svh]"
         art={
           <ArtSection
             svg={SvgB}
-            className="text-pink-500"
+            className="text-people"
             mobileRotateAndStretch
             preserveAspectRatio="xMidYMid meet"
             unsetWidthHeight
           />
         }
+        ariaLabel="Our vision"
       >
         <StoryTextElement
           title="Our Vision"

--- a/src/components/Storybanner.tsx
+++ b/src/components/Storybanner.tsx
@@ -10,9 +10,10 @@ const ExamplePage: React.FC = () => {
   return (
     <>
       <SubsectionBanner
+        id="people"
         textSide="right"
         tone="people"
-        height="h-[90svh]"
+        // height="h-[90svh]"
         art={
           <ArtSection
             svg={SvgA}
@@ -32,9 +33,9 @@ const ExamplePage: React.FC = () => {
         />
       </SubsectionBanner>
       <SubsectionBanner
+        id="mission"
         textSide="left"
         tone="health"
-        height="h-[90svh]"
         art={
           <ArtSection
             svg={SvgA}
@@ -59,9 +60,9 @@ const ExamplePage: React.FC = () => {
       </SubsectionBanner>
 
       <SubsectionBanner
+        id="vision"
         textSide="right"
         tone="data"
-        height="h-[90svh]"
         art={
           <ArtSection
             svg={SvgB}

--- a/src/components/Storybanner.tsx
+++ b/src/components/Storybanner.tsx
@@ -20,6 +20,7 @@ const ExamplePage: React.FC = () => {
             mobileRotateAndStretch
             preserveAspectRatio="xMidYMid meet"
             unsetWidthHeight
+            strokeWidth="3px"
           />
         }
         ariaLabel="Our mission"
@@ -47,6 +48,7 @@ const ExamplePage: React.FC = () => {
             mobileRotateAndStretch
             preserveAspectRatio="xMidYMid meet"
             unsetWidthHeight
+            strokeWidth="5px"
           />
         }
         ariaLabel="Our vision"

--- a/src/components/Storybanner.tsx
+++ b/src/components/Storybanner.tsx
@@ -5,7 +5,7 @@ import { StoryTextElement } from './ui/StoryTextElement';
 import { ArtSection } from './ui/ArtSection';
 
 const ExamplePage: React.FC = () => {
-  const [SvgA, SvgB] = useShuffledSvgs();
+  const [SvgA, SvgB, SvgC] = useShuffledSvgs();
 
   return (
     <>
@@ -20,7 +20,7 @@ const ExamplePage: React.FC = () => {
             mobileRotateAndStretch
             preserveAspectRatio="xMidYMid meet"
             unsetWidthHeight
-            strokeWidth="3px"
+            strokeWidth="1px"
           />
         }
         ariaLabel="Our People"
@@ -38,7 +38,7 @@ const ExamplePage: React.FC = () => {
         tone="health"
         art={
           <ArtSection
-            svg={SvgA}
+            svg={SvgB}
             mobileRotateAndStretch
             preserveAspectRatio="xMidYMid meet"
             unsetWidthHeight
@@ -65,7 +65,7 @@ const ExamplePage: React.FC = () => {
         tone="data"
         art={
           <ArtSection
-            svg={SvgB}
+            svg={SvgC}
             mobileRotateAndStretch
             preserveAspectRatio="xMidYMid meet"
             unsetWidthHeight

--- a/src/components/Storybanner.tsx
+++ b/src/components/Storybanner.tsx
@@ -1,0 +1,63 @@
+// ExamplePage.tsx
+import * as React from 'react';
+import { useShuffledSvgs } from '../hooks/useShuffledSvgs';
+import { SubsectionBanner } from './ui/SubsectionBanner';
+import { StoryTextElement } from './ui/StoryTextElement';
+import { ArtSection } from './ui/ArtSection';
+
+const ExamplePage: React.FC = () => {
+  const [SvgA, SvgB] = useShuffledSvgs();
+
+  return (
+    <>
+      <SubsectionBanner
+        textSide="left" // desktop: text left, art right
+        bgColor="bg-indigo-50"
+        height="h-[100svh]"
+        art={
+          <ArtSection
+            svg={SvgA}
+            className="text-yellow-500"
+            mobileRotateAndStretch // rotate + stretch on mobile
+            preserveAspectRatio="xMidYMid meet"
+            unsetWidthHeight
+          />
+        }
+      >
+        <StoryTextElement
+          title="Our Mission"
+          paragraph="We build amazing experiences that scale across devices."
+          bullets={[
+            'Responsive Design',
+            'High Performance',
+            'Scalable Architecture',
+          ]}
+          badges={['Responsive', 'Scalable', 'Modern']}
+        />
+      </SubsectionBanner>
+
+      <SubsectionBanner
+        textSide="right" // desktop: text right, art left
+        bgColor="bg-emerald-50"
+        height="h-[100svh]"
+        art={
+          <ArtSection
+            svg={SvgB}
+            className="text-pink-500"
+            mobileRotateAndStretch
+            preserveAspectRatio="xMidYMid meet"
+            unsetWidthHeight
+          />
+        }
+      >
+        <StoryTextElement
+          title="Our Vision"
+          paragraph="Empowering teams to ship products faster with confidence."
+          badges={['Fast', 'Reliable']}
+        />
+      </SubsectionBanner>
+    </>
+  );
+};
+
+export default ExamplePage;

--- a/src/components/ui/ArtSection.tsx
+++ b/src/components/ui/ArtSection.tsx
@@ -1,0 +1,81 @@
+// src/components/ui/ArtSection.tsx
+import * as React from 'react';
+
+type SvgLike =
+  | React.ComponentType<React.SVGProps<SVGSVGElement>>
+  | React.ReactElement<React.SVGProps<SVGSVGElement>>;
+
+export interface ArtSectionProps {
+  svg: SvgLike;
+  className?: string;
+  wrapperClassName?: string;
+  preserveAspectRatio?: string | null;
+  unsetWidthHeight?: boolean;
+  /** Rotate and stretch on mobile so the path spans side-to-side */
+  mobileRotateAndStretch?: boolean;
+}
+
+export const ArtSection: React.FC<ArtSectionProps> = ({
+  svg,
+  className,
+  wrapperClassName,
+  preserveAspectRatio = 'xMidYMid meet',
+  unsetWidthHeight = true,
+  mobileRotateAndStretch = true,
+}) => {
+  const wrapper = (child: React.ReactNode) => (
+    <div
+      className={[
+        'flex h-full w-full items-center justify-center',
+        // Clip on mobile so long paths don’t bleed into other sections
+        'overflow-hidden md:overflow-visible',
+        'pointer-events-none', // decorative art, no accidental taps
+        wrapperClassName,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      aria-hidden="true"
+    >
+      {child}
+    </div>
+  );
+
+  const mobileArtClasses = mobileRotateAndStretch
+    ? 'rotate-90 md:rotate-0 w-[140%] max-w-none h-auto md:w-auto md:h-full'
+    : 'w-full h-auto md:h-full md:w-auto';
+
+  const mergedClass = [mobileArtClasses, className].filter(Boolean).join(' ');
+
+  if (
+    typeof svg === 'function' ||
+    (typeof svg === 'object' && !React.isValidElement(svg))
+  ) {
+    const SvgComp = svg as React.ComponentType<React.SVGProps<SVGSVGElement>>;
+    return wrapper(
+      <SvgComp
+        className={mergedClass}
+        preserveAspectRatio={preserveAspectRatio ?? undefined}
+        width={unsetWidthHeight ? undefined : undefined}
+        height={unsetWidthHeight ? undefined : undefined}
+      />
+    );
+  }
+
+  if (React.isValidElement<React.SVGProps<SVGSVGElement>>(svg)) {
+    const incoming = svg.props;
+    return wrapper(
+      React.cloneElement(svg, {
+        ...incoming,
+        className: [incoming.className, mergedClass].filter(Boolean).join(' '),
+        preserveAspectRatio:
+          preserveAspectRatio === null
+            ? incoming.preserveAspectRatio
+            : preserveAspectRatio,
+        width: unsetWidthHeight ? undefined : incoming.width,
+        height: unsetWidthHeight ? undefined : incoming.height,
+      })
+    );
+  }
+
+  return wrapper(svg as React.ReactNode);
+};

--- a/src/components/ui/ArtSection.tsx
+++ b/src/components/ui/ArtSection.tsx
@@ -1,4 +1,3 @@
-// src/components/ui/ArtSection.tsx
 import * as React from 'react';
 
 type SvgLike =
@@ -10,72 +9,80 @@ export interface ArtSectionProps {
   className?: string;
   wrapperClassName?: string;
   preserveAspectRatio?: string | null;
-  unsetWidthHeight?: boolean;
-  /** Rotate and stretch on mobile so the path spans side-to-side */
-  mobileRotateAndStretch?: boolean;
+  unsetWidthHeight?: boolean; // default true
+  mobileRotateAndStretch?: boolean; // default true
+  decorative?: boolean; // default true
 }
 
-export const ArtSection: React.FC<ArtSectionProps> = ({
-  svg,
-  className,
-  wrapperClassName,
-  preserveAspectRatio = 'xMidYMid meet',
-  unsetWidthHeight = true,
-  mobileRotateAndStretch = true,
-}) => {
-  const wrapper = (child: React.ReactNode) => (
-    <div
-      className={[
-        'flex h-full w-full items-center justify-center',
-        // Clip on mobile so long paths don’t bleed into other sections
-        'overflow-hidden md:overflow-visible',
-        'pointer-events-none', // decorative art, no accidental taps
-        wrapperClassName,
-      ]
-        .filter(Boolean)
-        .join(' ')}
-      aria-hidden="true"
-    >
-      {child}
-    </div>
-  );
-
-  const mobileArtClasses = mobileRotateAndStretch
-    ? 'rotate-90 md:rotate-0 w-[140%] max-w-none h-auto md:w-auto md:h-full'
-    : 'w-full h-auto md:h-full md:w-auto';
-
-  const mergedClass = [mobileArtClasses, className].filter(Boolean).join(' ');
-
-  if (
-    typeof svg === 'function' ||
-    (typeof svg === 'object' && !React.isValidElement(svg))
-  ) {
-    const SvgComp = svg as React.ComponentType<React.SVGProps<SVGSVGElement>>;
-    return wrapper(
-      <SvgComp
-        className={mergedClass}
-        preserveAspectRatio={preserveAspectRatio ?? undefined}
-        width={unsetWidthHeight ? undefined : undefined}
-        height={unsetWidthHeight ? undefined : undefined}
-      />
+export const ArtSection: React.FC<ArtSectionProps> = React.memo(
+  ({
+    svg,
+    className,
+    wrapperClassName,
+    preserveAspectRatio = 'xMidYMid meet',
+    unsetWidthHeight = true,
+    mobileRotateAndStretch = true,
+    decorative = true,
+  }) => {
+    const wrapper = (child: React.ReactNode) => (
+      <div
+        className={[
+          'flex h-full w-full items-center justify-center',
+          'overflow-hidden md:overflow-visible',
+          'pointer-events-none select-none',
+          wrapperClassName,
+        ]
+          .filter(Boolean)
+          .join(' ')}
+        aria-hidden={decorative || undefined}
+      >
+        {child}
+      </div>
     );
-  }
 
-  if (React.isValidElement<React.SVGProps<SVGSVGElement>>(svg)) {
-    const incoming = svg.props;
-    return wrapper(
-      React.cloneElement(svg, {
-        ...incoming,
-        className: [incoming.className, mergedClass].filter(Boolean).join(' '),
-        preserveAspectRatio:
-          preserveAspectRatio === null
-            ? incoming.preserveAspectRatio
-            : preserveAspectRatio,
-        width: unsetWidthHeight ? undefined : incoming.width,
-        height: unsetWidthHeight ? undefined : incoming.height,
-      })
-    );
-  }
+    const mobileArtClasses = mobileRotateAndStretch
+      ? 'origin-center rotate-90 md:rotate-0 w-[160%] max-w-none h-auto md:w-auto md:h-full'
+      : 'w-full h-auto md:h-full md:w-auto';
 
-  return wrapper(svg as React.ReactNode);
-};
+    const mergedClass = [mobileArtClasses, className].filter(Boolean).join(' ');
+
+    // SVGR component
+    if (
+      typeof svg === 'function' ||
+      (typeof svg === 'object' && !React.isValidElement(svg))
+    ) {
+      const SvgComp = svg as React.ComponentType<React.SVGProps<SVGSVGElement>>;
+      return wrapper(
+        <SvgComp
+          className={mergedClass}
+          preserveAspectRatio={preserveAspectRatio ?? undefined}
+          focusable={false}
+          aria-hidden={decorative || undefined}
+        />
+      );
+    }
+
+    // React element
+    if (React.isValidElement<React.SVGProps<SVGSVGElement>>(svg)) {
+      const incoming = svg.props;
+      return wrapper(
+        React.cloneElement(svg, {
+          ...incoming,
+          className: [incoming.className, mergedClass]
+            .filter(Boolean)
+            .join(' '),
+          preserveAspectRatio:
+            preserveAspectRatio === null
+              ? incoming.preserveAspectRatio
+              : preserveAspectRatio,
+          width: unsetWidthHeight ? undefined : incoming.width,
+          height: unsetWidthHeight ? undefined : incoming.height,
+          focusable: false,
+          'aria-hidden': decorative || undefined,
+        })
+      );
+    }
+
+    return wrapper(svg as React.ReactNode);
+  }
+);

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,13 +1,43 @@
 // components/Badge.tsx
-import React from 'react';
+import * as React from 'react';
 
 export interface BadgeProps {
-  /** Text to display inside the badge */
   label: string;
+  tone?:
+    | 'primary'
+    | 'health'
+    | 'people'
+    | 'info'
+    | 'success'
+    | 'warning'
+    | 'neutral';
 }
 
-export const Badge: React.FC<BadgeProps> = ({ label }) => (
-  <span className="rounded-full bg-blue-200 px-3 py-1 text-sm font-medium text-blue-800">
-    {label}
-  </span>
+const toneClass: Record<NonNullable<BadgeProps['tone']>, string> = {
+  primary:
+    'ring-[color-mix(in oklch,var(--color-primary)45%,transparent)] bg-[color-mix(in oklch,var(--color-primary)18%,transparent)]',
+  health:
+    'ring-[color-mix(in oklch,var(--color-health)45%,transparent)]  bg-[color-mix(in oklch,var(--color-health)18%,transparent)]',
+  people:
+    'ring-[color-mix(in oklch,var(--color-people)45%,transparent)]  bg-[color-mix(in oklch,var(--color-people)18%,transparent)]',
+  info: 'ring-[color-mix(in oklch,var(--color-info)45%,transparent)]    bg-[color-mix(in oklch,var(--color-info)18%,transparent)]',
+  success:
+    'ring-[color-mix(in oklch,var(--color-success)45%,transparent)] bg-[color-mix(in oklch,var(--color-success)18%,transparent)]',
+  warning:
+    'ring-[color-mix(in oklch,var(--color-warning)45%,transparent)] bg-[color-mix(in oklch,var(--color-warning)18%,transparent)]',
+  neutral:
+    'ring-[color-mix(in oklch,var(--color-border)60%,transparent)]  bg-[color-mix(in oklch,var(--color-border)18%,transparent)]',
+};
+
+export const Badge: React.FC<BadgeProps> = React.memo(
+  ({ label, tone = 'neutral' }) => (
+    <span
+      className={[
+        'text-small text-ink/80 inline-flex items-center rounded-full px-2.5 py-1 font-medium ring-1 backdrop-blur-sm',
+        toneClass[tone],
+      ].join(' ')}
+    >
+      {label}
+    </span>
+  )
 );

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,0 +1,13 @@
+// components/Badge.tsx
+import React from 'react';
+
+export interface BadgeProps {
+  /** Text to display inside the badge */
+  label: string;
+}
+
+export const Badge: React.FC<BadgeProps> = ({ label }) => (
+  <span className="rounded-full bg-blue-200 px-3 py-1 text-sm font-medium text-blue-800">
+    {label}
+  </span>
+);

--- a/src/components/ui/LinksList.tsx
+++ b/src/components/ui/LinksList.tsx
@@ -1,6 +1,11 @@
-import * as React from 'react';
-
 type Item = { id: string; label: string };
+
+type LinksListProps = {
+  className?: string;
+  activeId?: string | null;
+  onClick?: () => void;
+  items?: Item[];
+};
 
 export function LinksList({
   className,
@@ -14,32 +19,29 @@ export function LinksList({
     { id: 'projects', label: 'Projects' },
     { id: 'ongoings', label: 'Ongoings' },
   ],
-}: {
-  className?: string;
-  activeId?: string | null;
-  onClick?: () => void;
-  items?: Item[];
-}) {
+}: LinksListProps) {
   return (
-    <div className={className}>
+    <ul className={className}>
       {items.map((it) => {
         const active = activeId === it.id;
         return (
-          <a
-            key={it.id}
-            href={`#${it.id}`}
-            onClick={onClick}
-            className={[
-              'focus-ring rounded-sm px-1 py-0.5 transition-colors',
-              active
-                ? 'text-primary underline decoration-2 underline-offset-4'
-                : 'text-muted hover:text-ink',
-            ].join(' ')}
-          >
-            {it.label}
-          </a>
+          <li key={it.id}>
+            <a
+              href={`#${it.id}`}
+              onClick={onClick}
+              aria-current={active ? 'true' : undefined}
+              className={[
+                'focus-ring rounded-sm px-1 py-0.5 transition-colors',
+                active
+                  ? 'text-primary underline decoration-2 underline-offset-4'
+                  : 'text-muted hover:text-ink',
+              ].join(' ')}
+            >
+              {it.label}
+            </a>
+          </li>
         );
       })}
-    </div>
+    </ul>
   );
 }

--- a/src/components/ui/LinksList.tsx
+++ b/src/components/ui/LinksList.tsx
@@ -1,27 +1,45 @@
-// src/components/LinksList.tsx
-import React from 'react';
-import { NAV_LINKS } from '../../constants/NavLinks';
+import * as React from 'react';
 
-interface LinksListProps {
-  className?: string;
-  onClick?: () => void;
-}
+type Item = { id: string; label: string };
 
-export const LinksList: React.FC<LinksListProps> = ({
-  className = '',
+export function LinksList({
+  className,
+  activeId,
   onClick,
-}) => (
-  <ul className={className}>
-    {NAV_LINKS.map(({ href, label }) => (
-      <li key={href}>
-        <a
-          href={href}
-          className="block transition-colors hover:text-gray-900"
-          onClick={onClick}
-        >
-          {label}
-        </a>
-      </li>
-    ))}
-  </ul>
-);
+  items = [
+    { id: 'hero', label: 'Home' },
+    { id: 'people', label: 'People' },
+    { id: 'mission', label: 'Mission' },
+    { id: 'vision', label: 'Vision' },
+    { id: 'projects', label: 'Projects' },
+    { id: 'ongoings', label: 'Ongoings' },
+  ],
+}: {
+  className?: string;
+  activeId?: string | null;
+  onClick?: () => void;
+  items?: Item[];
+}) {
+  return (
+    <div className={className}>
+      {items.map((it) => {
+        const active = activeId === it.id;
+        return (
+          <a
+            key={it.id}
+            href={`#${it.id}`}
+            onClick={onClick}
+            className={[
+              'focus-ring rounded-sm px-1 py-0.5 transition-colors',
+              active
+                ? 'text-primary underline decoration-2 underline-offset-4'
+                : 'text-muted hover:text-ink',
+            ].join(' ')}
+          >
+            {it.label}
+          </a>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/ui/StoryTextElement.tsx
+++ b/src/components/ui/StoryTextElement.tsx
@@ -1,0 +1,46 @@
+// components/StoryTextElement.tsx
+import * as React from 'react';
+import { Badge } from './Badge';
+
+export interface StoryTextElementProps {
+  title: string;
+  paragraph?: string;
+  bullets?: string[];
+  badges?: string[];
+}
+
+export const StoryTextElement: React.FC<StoryTextElementProps> = ({
+  title,
+  paragraph,
+  bullets,
+  badges,
+}) => (
+  <div className="mx-auto max-w-prose space-y-5 text-left md:space-y-6">
+    {/* +1 step on mobile */}
+    <h2 className="text-balance text-3xl font-semibold tracking-tight md:text-4xl lg:text-5xl">
+      {title}
+    </h2>
+
+    {paragraph && (
+      <p className="text-base leading-7 text-gray-700 md:text-lg md:leading-8">
+        {paragraph}
+      </p>
+    )}
+
+    {bullets && bullets.length > 0 && (
+      <ul className="list-disc space-y-2 pl-5 text-base md:text-lg">
+        {bullets.map((item, idx) => (
+          <li key={idx}>{item}</li>
+        ))}
+      </ul>
+    )}
+
+    {badges && badges.length > 0 && (
+      <div className="flex flex-wrap gap-2 pt-1">
+        {badges.map((label, idx) => (
+          <Badge key={idx} label={label} />
+        ))}
+      </div>
+    )}
+  </div>
+);

--- a/src/components/ui/StoryTextElement.tsx
+++ b/src/components/ui/StoryTextElement.tsx
@@ -9,38 +9,30 @@ export interface StoryTextElementProps {
   badges?: string[];
 }
 
-export const StoryTextElement: React.FC<StoryTextElementProps> = ({
-  title,
-  paragraph,
-  bullets,
-  badges,
-}) => (
-  <div className="mx-auto max-w-prose space-y-5 text-left md:space-y-6">
-    {/* +1 step on mobile */}
-    <h2 className="text-balance text-3xl font-semibold tracking-tight md:text-4xl lg:text-5xl">
-      {title}
-    </h2>
+export const StoryTextElement: React.FC<StoryTextElementProps> = React.memo(
+  ({ title, paragraph, bullets, badges }) => (
+    <div className="measure stack-m mx-auto text-left">
+      <h2 className="font-display text-h2 text-ink font-semibold tracking-tight">
+        {title}
+      </h2>
 
-    {paragraph && (
-      <p className="text-base leading-7 text-gray-700 md:text-lg md:leading-8">
-        {paragraph}
-      </p>
-    )}
+      {paragraph && <p className="text-body text-muted">{paragraph}</p>}
 
-    {bullets && bullets.length > 0 && (
-      <ul className="list-disc space-y-2 pl-5 text-base md:text-lg">
-        {bullets.map((item, idx) => (
-          <li key={idx}>{item}</li>
-        ))}
-      </ul>
-    )}
+      {bullets?.length ? (
+        <ul className="text-body text-ink list-disc space-y-1.5 pl-5">
+          {bullets.map((item, i) => (
+            <li key={i}>{item}</li>
+          ))}
+        </ul>
+      ) : null}
 
-    {badges && badges.length > 0 && (
-      <div className="flex flex-wrap gap-2 pt-1">
-        {badges.map((label, idx) => (
-          <Badge key={idx} label={label} />
-        ))}
-      </div>
-    )}
-  </div>
+      {badges?.length ? (
+        <div className="flex flex-wrap gap-2 pt-1">
+          {badges.map((label, i) => (
+            <Badge key={i} label={label} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
 );

--- a/src/components/ui/StoryTextElement.tsx
+++ b/src/components/ui/StoryTextElement.tsx
@@ -1,5 +1,6 @@
 // components/StoryTextElement.tsx
 import * as React from 'react';
+import { useInViewOnce } from '../../hooks/useInViewOnce';
 import { Badge } from './Badge';
 
 export interface StoryTextElementProps {
@@ -10,29 +11,42 @@ export interface StoryTextElementProps {
 }
 
 export const StoryTextElement: React.FC<StoryTextElementProps> = React.memo(
-  ({ title, paragraph, bullets, badges }) => (
-    <div className="measure stack-m mx-auto text-left">
-      <h2 className="font-display text-h2 text-ink font-semibold tracking-tight">
-        {title}
-      </h2>
+  ({ title, paragraph, bullets, badges }) => {
+    const { ref, inView } = useInViewOnce<HTMLDivElement>();
+    return (
+      <div
+        ref={ref}
+        className={[
+          'measure stack-m reveal mx-auto text-left',
+          inView && 'inview',
+        ]
+          .filter(Boolean)
+          .join(' ')}
+      >
+        <div className="measure stack-m mx-auto text-left">
+          <h2 className="font-display text-h2 text-ink font-semibold tracking-tight">
+            {title}
+          </h2>
 
-      {paragraph && <p className="text-body text-muted">{paragraph}</p>}
+          {paragraph && <p className="text-body text-muted">{paragraph}</p>}
 
-      {bullets?.length ? (
-        <ul className="text-body text-ink list-disc space-y-1.5 pl-5">
-          {bullets.map((item, i) => (
-            <li key={i}>{item}</li>
-          ))}
-        </ul>
-      ) : null}
+          {bullets?.length ? (
+            <ul className="text-body text-ink list-disc space-y-1.5 pl-5">
+              {bullets.map((item, i) => (
+                <li key={i}>{item}</li>
+              ))}
+            </ul>
+          ) : null}
 
-      {badges?.length ? (
-        <div className="flex flex-wrap gap-2 pt-1">
-          {badges.map((label, i) => (
-            <Badge key={i} label={label} />
-          ))}
+          {badges?.length ? (
+            <div className="flex flex-wrap gap-2 pt-1">
+              {badges.map((label, i) => (
+                <Badge key={i} label={label} />
+              ))}
+            </div>
+          ) : null}
         </div>
-      ) : null}
-    </div>
-  )
+      </div>
+    );
+  }
 );

--- a/src/components/ui/SubsectionBanner.tsx
+++ b/src/components/ui/SubsectionBanner.tsx
@@ -1,9 +1,30 @@
 import * as React from 'react';
 
+type Tone = 'neutral' | 'data' | 'health' | 'people' | 'primary';
+
+function toneToClasses(tone: Tone) {
+  switch (tone) {
+    case 'data':
+      return { bg: 'bg-surface-data', artText: 'text-primary' };
+    case 'health':
+      return { bg: 'bg-surface-health', artText: 'text-health' };
+    case 'people':
+      return { bg: 'bg-surface-people', artText: 'text-people' };
+    case 'primary':
+      return { bg: 'bg-surface-1', artText: 'text-primary' };
+    default:
+      return { bg: 'bg-surface-1', artText: 'text-muted' };
+  }
+}
+
 export interface SubsectionBannerProps {
   textSide: 'left' | 'right';
-  bgColor?: string; // prefer token surfaces
-  height?: string; // e.g. 'h-[90svh]'
+  /** If provided, overrides the tone surface */
+  bgColor?: string;
+  /** Picks default surface + default art color */
+  tone?: Tone;
+  /** Height class, e.g. 'h-[90svh]' */
+  height?: string;
   art: React.ReactNode;
   children: React.ReactNode;
   id?: string;
@@ -13,13 +34,15 @@ export interface SubsectionBannerProps {
 export const SubsectionBanner: React.FC<SubsectionBannerProps> = React.memo(
   ({
     textSide,
-    bgColor = 'bg-surface-1',
+    bgColor,
+    tone = 'neutral',
     height = 'h-[90svh]',
     art,
     children,
     id,
     ariaLabel,
   }) => {
+    const { bg, artText } = toneToClasses(tone);
     const textDesktopOrder = textSide === 'left' ? 'md:order-1' : 'md:order-2';
     const artDesktopOrder = textSide === 'left' ? 'md:order-2' : 'md:order-1';
 
@@ -31,10 +54,12 @@ export const SubsectionBanner: React.FC<SubsectionBannerProps> = React.memo(
         className={[
           'grid',
           height,
-          bgColor,
+          bgColor ?? bg, // bgColor wins, else tone surface
           'grid-rows-[auto,1fr] md:grid-cols-2 md:grid-rows-1',
         ].join(' ')}
+        data-section={id || undefined}
       >
+        {/* Text */}
         <div
           className={[
             'order-1',
@@ -44,7 +69,11 @@ export const SubsectionBanner: React.FC<SubsectionBannerProps> = React.memo(
         >
           <div className="w-full px-6 py-10 md:px-12 md:py-16">{children}</div>
         </div>
-        <div className={['order-2', artDesktopOrder, 'min-h-0'].join(' ')}>
+
+        {/* Art: default color from tone; child color (text-*) overrides if provided */}
+        <div
+          className={['order-2', artDesktopOrder, 'min-h-0', artText].join(' ')}
+        >
           {art}
         </div>
       </section>

--- a/src/components/ui/SubsectionBanner.tsx
+++ b/src/components/ui/SubsectionBanner.tsx
@@ -36,7 +36,7 @@ export const SubsectionBanner: React.FC<SubsectionBannerProps> = React.memo(
     textSide,
     bgColor,
     tone = 'neutral',
-    height = 'h-[90svh]',
+    height = 'h-[90svh] scroll-mt-nav',
     art,
     children,
     id,

--- a/src/components/ui/SubsectionBanner.tsx
+++ b/src/components/ui/SubsectionBanner.tsx
@@ -5,7 +5,7 @@ type Tone = 'neutral' | 'data' | 'health' | 'people' | 'primary';
 function toneToClasses(tone: Tone) {
   switch (tone) {
     case 'data':
-      return { bg: 'bg-surface-data', artText: 'text-primary' };
+      return { bg: 'bg-surface-data', artText: 'text-data' };
     case 'health':
       return { bg: 'bg-surface-health', artText: 'text-health' };
     case 'people':

--- a/src/components/ui/SubsectionBanner.tsx
+++ b/src/components/ui/SubsectionBanner.tsx
@@ -1,0 +1,50 @@
+// src/components/ui/SubsectionBanner.tsx
+import * as React from 'react';
+
+export interface SubsectionBannerProps {
+  textSide: 'left' | 'right';
+  bgColor?: string;
+  height?: string; // e.g. 'h-[100svh]' | 'h-[75svh]'
+  art: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export const SubsectionBanner: React.FC<SubsectionBannerProps> = ({
+  textSide,
+  bgColor = 'bg-gray-100',
+  height = 'h-[100svh]',
+  art,
+  children,
+}) => {
+  // On mobile: text = order-1, art = order-2 (always)
+  // On desktop: swap based on textSide
+  const textDesktopOrder = textSide === 'left' ? 'md:order-1' : 'md:order-2';
+  const artDesktopOrder = textSide === 'left' ? 'md:order-2' : 'md:order-1';
+
+  return (
+    <section
+      className={[
+        'grid',
+        height,
+        bgColor,
+        'grid-rows-2 md:grid-cols-2 md:grid-rows-1',
+      ].join(' ')}
+    >
+      {/* Text */}
+      <div
+        className={[
+          'order-1',
+          textDesktopOrder,
+          'flex min-h-0 items-center',
+        ].join(' ')}
+      >
+        <div className="w-full p-10 md:p-12">{children}</div>
+      </div>
+
+      {/* Art */}
+      <div className={['order-2', artDesktopOrder, 'min-h-0'].join(' ')}>
+        {art}
+      </div>
+    </section>
+  );
+};

--- a/src/components/ui/SubsectionBanner.tsx
+++ b/src/components/ui/SubsectionBanner.tsx
@@ -1,50 +1,53 @@
-// src/components/ui/SubsectionBanner.tsx
 import * as React from 'react';
 
 export interface SubsectionBannerProps {
   textSide: 'left' | 'right';
-  bgColor?: string;
-  height?: string; // e.g. 'h-[100svh]' | 'h-[75svh]'
+  bgColor?: string; // prefer token surfaces
+  height?: string; // e.g. 'h-[90svh]'
   art: React.ReactNode;
   children: React.ReactNode;
+  id?: string;
+  ariaLabel?: string;
 }
 
-export const SubsectionBanner: React.FC<SubsectionBannerProps> = ({
-  textSide,
-  bgColor = 'bg-gray-100',
-  height = 'h-[100svh]',
-  art,
-  children,
-}) => {
-  // On mobile: text = order-1, art = order-2 (always)
-  // On desktop: swap based on textSide
-  const textDesktopOrder = textSide === 'left' ? 'md:order-1' : 'md:order-2';
-  const artDesktopOrder = textSide === 'left' ? 'md:order-2' : 'md:order-1';
+export const SubsectionBanner: React.FC<SubsectionBannerProps> = React.memo(
+  ({
+    textSide,
+    bgColor = 'bg-surface-1',
+    height = 'h-[90svh]',
+    art,
+    children,
+    id,
+    ariaLabel,
+  }) => {
+    const textDesktopOrder = textSide === 'left' ? 'md:order-1' : 'md:order-2';
+    const artDesktopOrder = textSide === 'left' ? 'md:order-2' : 'md:order-1';
 
-  return (
-    <section
-      className={[
-        'grid',
-        height,
-        bgColor,
-        'grid-rows-2 md:grid-cols-2 md:grid-rows-1',
-      ].join(' ')}
-    >
-      {/* Text */}
-      <div
+    return (
+      <section
+        id={id}
+        role="region"
+        aria-label={ariaLabel}
         className={[
-          'order-1',
-          textDesktopOrder,
-          'flex min-h-0 items-center',
+          'grid',
+          height,
+          bgColor,
+          'grid-rows-[auto,1fr] md:grid-cols-2 md:grid-rows-1',
         ].join(' ')}
       >
-        <div className="w-full p-10 md:p-12">{children}</div>
-      </div>
-
-      {/* Art */}
-      <div className={['order-2', artDesktopOrder, 'min-h-0'].join(' ')}>
-        {art}
-      </div>
-    </section>
-  );
-};
+        <div
+          className={[
+            'order-1',
+            textDesktopOrder,
+            'flex min-h-0 items-center',
+          ].join(' ')}
+        >
+          <div className="w-full px-6 py-10 md:px-12 md:py-16">{children}</div>
+        </div>
+        <div className={['order-2', artDesktopOrder, 'min-h-0'].join(' ')}>
+          {art}
+        </div>
+      </section>
+    );
+  }
+);

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,8 @@
+declare module '*.svg' {
+  import * as React from 'react';
+  export const ReactComponent: React.FunctionComponent<
+    React.SVGProps<SVGSVGElement> & { title?: string }
+  >;
+  const src: string;
+  export default src;
+}

--- a/src/hooks/useActiveSection.ts
+++ b/src/hooks/useActiveSection.ts
@@ -1,0 +1,44 @@
+// src/hooks/useActiveSection.ts
+import { useEffect, useRef, useState } from 'react';
+
+export function useActiveSection(
+  ids: readonly string[],
+  rootMargin = '-35% 0% -55% 0%'
+) {
+  const [active, setActive] = useState<string | null>(ids[0] ?? null);
+
+  // keep the latest active without re-subscribing the observer
+  const activeRef = useRef(active);
+  useEffect(() => {
+    activeRef.current = active;
+  }, [active]);
+
+  useEffect(() => {
+    if (!ids.length) return;
+
+    const sections = ids
+      .map((id) => document.getElementById(id))
+      .filter((el): el is HTMLElement => !!el);
+
+    if (!sections.length) return;
+
+    const obs = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => b.intersectionRatio - a.intersectionRatio);
+
+        const top = visible[0]?.target as HTMLElement | undefined;
+        if (top?.id && top.id !== activeRef.current) {
+          setActive(top.id);
+        }
+      },
+      { root: null, rootMargin, threshold: [0.1, 0.25, 0.5, 0.75] }
+    );
+
+    sections.forEach((el) => obs.observe(el));
+    return () => obs.disconnect();
+  }, [ids, rootMargin]); // ✅ no 'active' in deps
+
+  return active;
+}

--- a/src/hooks/useInViewOnce.ts
+++ b/src/hooks/useInViewOnce.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef, useState } from 'react';
+
+export function useInViewOnce<T extends HTMLElement>(
+  options?: IntersectionObserverInit
+) {
+  const ref = useRef<T | null>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    if (!ref.current || inView) return;
+    const node = ref.current;
+
+    const obs = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((e) => {
+          if (e.isIntersecting) {
+            setInView(true);
+            obs.disconnect();
+          }
+        });
+      },
+      { rootMargin: '0px 0px -10% 0px', threshold: 0.15, ...options }
+    );
+
+    obs.observe(node);
+    return () => obs.disconnect();
+  }, [inView, options]);
+
+  return { ref, inView };
+}

--- a/src/hooks/useShuffledSvgs.ts
+++ b/src/hooks/useShuffledSvgs.ts
@@ -1,7 +1,6 @@
 // src/hooks/useShuffledSvgs.ts
 import { useRef } from 'react';
 import type { ComponentType, SVGProps } from 'react';
-import SampleSVG from '../assets/sample.svg?react';
 import LoopRiseSVG from '../assets/flow/loop-rise.svg?react';
 import BroadUndulationSVG from '../assets/flow/broad-undulation.svg?react';
 import DoubleSCurveSVG from '../assets/flow/double-s-curve.svg?react';
@@ -16,7 +15,6 @@ import { shuffleArray } from '../utils/shuffle';
 export type SvgComp = ComponentType<SVGProps<SVGSVGElement>>;
 
 const SVGS = [
-  SampleSVG,
   LoopRiseSVG,
   BroadUndulationSVG,
   DoubleSCurveSVG,

--- a/src/hooks/useShuffledSvgs.ts
+++ b/src/hooks/useShuffledSvgs.ts
@@ -1,5 +1,5 @@
 // src/hooks/useShuffledSvgs.ts
-import { useMemo } from 'react';
+import { useRef } from 'react';
 import type { ComponentType, SVGProps } from 'react';
 import SampleSVG from '../assets/sample.svg?react';
 import LoopRiseSVG from '../assets/flow/loop-rise.svg?react';
@@ -29,6 +29,7 @@ const SVGS = [
 ] as const satisfies readonly SvgComp[];
 
 export function useShuffledSvgs(): SvgComp[] {
-  // shuffles once per mount; if you want it stable across route changes, swap to useRef
-  return useMemo(() => shuffleArray([...SVGS]), []);
+  const ref = useRef<SvgComp[] | null>(null);
+  if (!ref.current) ref.current = shuffleArray([...SVGS]);
+  return ref.current;
 }

--- a/src/hooks/useShuffledSvgs.ts
+++ b/src/hooks/useShuffledSvgs.ts
@@ -1,0 +1,34 @@
+// src/hooks/useShuffledSvgs.ts
+import { useMemo } from 'react';
+import type { ComponentType, SVGProps } from 'react';
+import SampleSVG from '../assets/sample.svg?react';
+import LoopRiseSVG from '../assets/flow/loop-rise.svg?react';
+import BroadUndulationSVG from '../assets/flow/broad-undulation.svg?react';
+import DoubleSCurveSVG from '../assets/flow/double-s-curve.svg?react';
+import GentleWaveSVG from '../assets/flow/gentle-wave.svg?react';
+import LoftySpiralSVG from '../assets/flow/lofty-spiral.svg?react';
+import SingleLoopSVG from '../assets/flow/single-loop.svg?react';
+import SquigleOneSVG from '../assets/flow/squigle-one.svg?react';
+import TripleLoopSpiralSVG from '../assets/flow/triple-loop-spiral.svg?react';
+import WindingMeanderSVG from '../assets/flow/winding-meander.svg?react';
+import { shuffleArray } from '../utils/shuffle';
+
+export type SvgComp = ComponentType<SVGProps<SVGSVGElement>>;
+
+const SVGS = [
+  SampleSVG,
+  LoopRiseSVG,
+  BroadUndulationSVG,
+  DoubleSCurveSVG,
+  GentleWaveSVG,
+  LoftySpiralSVG,
+  SingleLoopSVG,
+  SquigleOneSVG,
+  TripleLoopSpiralSVG,
+  WindingMeanderSVG,
+] as const satisfies readonly SvgComp[];
+
+export function useShuffledSvgs(): SvgComp[] {
+  // shuffles once per mount; if you want it stable across route changes, swap to useRef
+  return useMemo(() => shuffleArray([...SVGS]), []);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -248,7 +248,7 @@
     text-wrap: balance;
   }
   .scroll-mt-nav {
-    scroll-margin-top: var(--nav-h);
+    scroll-margin-top: calc(var(--nav-h, 4rem));
   }
 
   /* Optional: drive stroke width by CSS var if you like */

--- a/src/index.css
+++ b/src/index.css
@@ -41,6 +41,9 @@
   --leading-head: 1.2;
   --leading-body: 1.7;
   --measure: 65ch;
+
+  /* Layout helpers */
+  --nav-h: 4rem; /* used by scroll-mt-nav */
 }
 
 /* 2.5) Follow system *only if* no manual class is set */
@@ -133,12 +136,62 @@
   }
 }
 
-/* 7) Utilities: fonts, type scale, rhythm, focus ring */
+/* 7) Utilities: fonts, colors, type, rhythm, helpers */
 @layer utilities {
+  /* Font families */
   .font-display {
     font-family: var(--font-display);
   }
 
+  /* Text colors mapped to tokens */
+  .text-ink {
+    color: var(--color-ink);
+  }
+  .text-muted {
+    color: var(--color-muted);
+  }
+  .text-primary {
+    color: var(--color-primary);
+  }
+  .text-health {
+    color: var(--color-health);
+  }
+  .text-people {
+    color: var(--color-people);
+  }
+  .text-info {
+    color: var(--color-info);
+  }
+  .text-success {
+    color: var(--color-success);
+  }
+  .text-warning {
+    color: var(--color-warning);
+  }
+
+  /* Background colors mapped to surfaces */
+  .bg-bg {
+    background-color: var(--color-bg);
+  }
+  .bg-surface-1 {
+    background-color: var(--color-surface-1);
+  }
+  .bg-surface-health {
+    background-color: var(--color-surface-health);
+  }
+  .bg-surface-data {
+    background-color: var(--color-surface-data);
+  }
+  .bg-surface-people {
+    background-color: var(--color-surface-people);
+  }
+
+  /* Borders */
+  .border-default {
+    border-color: var(--color-border);
+  }
+
+  /* Type scale */
   .text-hero {
     font-size: var(--text-hero);
     line-height: var(--leading-tight);
@@ -166,6 +219,7 @@
     line-height: 1.5;
   }
 
+  /* Measure & vertical rhythm */
   .measure {
     max-width: var(--measure);
   }
@@ -182,5 +236,53 @@
   /* Reusable focus ring for interactive elements */
   .focus-ring {
     @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)];
+  }
+
+  /* Headline balance + anchor offset */
+  .text-balance {
+    text-wrap: balance;
+  }
+  .scroll-mt-nav {
+    scroll-margin-top: var(--nav-h);
+  }
+
+  /* Optional: drive stroke width by CSS var if you like */
+  .stroke-var * {
+    stroke-width: var(--line-w, 2px);
+  }
+
+  /* In-view reveal animations */
+  .reveal {
+    opacity: 0;
+    transform: translateY(8px);
+    transition:
+      opacity 200ms ease-out,
+      transform 200ms ease-out;
+  }
+  .reveal.inview {
+    opacity: 1;
+    transform: none;
+  }
+
+  .reveal-x {
+    opacity: 0;
+    transform: translateX(var(--reveal-x, 8px));
+    transition:
+      opacity 220ms ease-out,
+      transform 220ms ease-out;
+  }
+  .reveal-x.inview {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* Reduced motion: disable/soften entrances */
+@media (prefers-reduced-motion: reduce) {
+  .reveal,
+  .reveal-x {
+    transition: none !important;
+    opacity: 1 !important;
+    transform: none !important;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -20,6 +20,7 @@
 
   /* Accents */
   --color-primary: #4f46e5; /* indigo */
+  --color-data: #3b82f6; /* blue */
   --color-health: #14b8a6; /* mint/teal */
   --color-people: #c026d3; /* orchid */
   --color-info: #0ea5e9;
@@ -59,6 +60,7 @@
     --color-muted: #9aa7b7;
 
     --color-primary: #818cf8;
+    --color-data: #60a5fa;
     --color-health: #5eead4;
     --color-people: #e879f9;
     --color-info: #7dd3fc;
@@ -152,6 +154,9 @@
   }
   .text-primary {
     color: var(--color-primary);
+  }
+  .text-data {
+    color: var(--color-data);
   }
   .text-health {
     color: var(--color-health);

--- a/src/utils/shuffle.ts
+++ b/src/utils/shuffle.ts
@@ -1,0 +1,9 @@
+// src/utils/shuffle.ts
+export function shuffleArray<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-svgr/client" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,5 +5,44 @@ import tailwindcss from '@tailwindcss/vite';
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), svgr(), tailwindcss()],
+  plugins: [react(), svgr({
+      include: ['**/src/assets/flow/**/*.svg?react'], // only the art lines
+      svgrOptions: {
+        // Make components colorable + crisp
+        svgProps: {
+          stroke: 'currentColor',
+          fill: 'none',
+          vectorEffect: 'non-scaling-stroke',
+        },
+        // If some files hardcode colors (e.g. #000), rewrite them:
+        replaceAttrValues: {
+          '#000': 'currentColor',
+          '#000000': 'currentColor',
+        },
+        // Run SVGO with targeted transforms
+        svgo: true,
+        svgoConfig: {
+          plugins: [
+            // Inline style="stroke:..." to attrs so we can strip them next
+            'convertStyleToAttrs',
+            // DO NOT remove viewBox
+            { name: 'removeViewBox', active: false },
+            // Strip any hard-coded stroke/fill so our svgProps win
+            { name: 'removeAttrs', params: { attrs: ['stroke', 'fill', 'stroke-width'] } },
+            // Re-add desired attributes at the root
+            {
+              name: 'addAttributesToSVGElement',
+              params: {
+                attributes: [
+                  { stroke: 'currentColor' },
+                  { fill: 'none' },
+                  { 'vector-effect': 'non-scaling-stroke' },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    }),
+     tailwindcss()],
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import svgr from 'vite-plugin-svgr';
 import tailwindcss from '@tailwindcss/vite';
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), svgr(), tailwindcss()],
 });


### PR DESCRIPTION
# Story Banner Polish — alternating layouts, tokenized type/colors, tone-driven art

## What & why
Implements a mobile-first **Story Banner** with alternating text/art layouts, consistent theming, and accessible defaults. SVG “art lines” are now responsive and colorable **without editing** the source files.

## Highlights
- **Mobile UX:** text always first; art rotates 90° to span side-to-side.
- **Desktop UX:** alternating left/right text & art; balanced paddings.
- **Tone-driven design:** `tone="people|health|data|primary|neutral"` picks the surface background and **default art color** via `currentColor`.
- **SVG at runtime:** color via tokens; line weight via prop/class; non-scaling strokes keep visual weight consistent.
- **Content-ready:** tokenized typography + badges; fluid type scale.

## Key changes
- **`SubsectionBanner`**
  - Adds `tone` to auto-select surface + default art color.
  - Mobile: text first; Desktop: alternates via order utilities.
  - `height` accepts a Tailwind class (e.g. `h-[90svh]`) verbatim.
  - A11y: `role="region"` + optional `ariaLabel`.
- **`ArtSection`**
  - `mobileRotateAndStretch` rotates art on small screens so the path traverses horizontally.
  - `strokeWidth` prop for runtime line weight (no SVG edits).
  - Sets `vectorEffect="non-scaling-stroke"`, `aria-hidden` by default.
  - **String fallback:** if a non-`?react` SVG slips in, render `<img>` and warn in dev (no more `data:image/...` strings).
- **`StoryTextElement`**
  - Uses tokenized type (`text-h2`, `text-body`) + colors (`text-ink`, `text-muted`); memoized.
- **`useShuffledSvgs`**
  - Stable shuffle compatible with React Strict Mode.
- **Example usage**
  - Three banners with `id` anchors and tones (`people`, `health`, `data`).
- **(If included in this branch)** SVGR/SVGO build config
  - Strip inline `stroke`, `fill`, `stroke-width`; inject `stroke="currentColor"`, `fill="none"`, `vector-effect="non-scaling-stroke"` so styles are runtime-controlled.

## Screenshots / behavior
- **Mobile:** text on top, rotated art crossing the section horizontally.
- **Desktop:** alternating sides, art contained, no bleed.
- **Dark mode:** surfaces + art colors adapt (tokens).

## How to test
1. `npm run dev`
2. **Mobile emulation:** text is first; art rotates and spans side-to-side.
3. **Desktop:** alternating sides; comfortable spacing/paddings.
4. **Colors:** toggle light/dark; art color follows `tone` (`people/health/data`).
5. **Line weight:** tweak `strokeWidth` per section; confirm effect.
6. **Anchors:** navbar links land headings fully below the sticky header (global `scroll-padding-top`).

## Accessibility
- Decorative SVGs: `aria-hidden` + `focusable={false}`.
- Sections: `role="region"` + `aria-label`.
- Reduced motion: reveal effects disabled/softened for `prefers-reduced-motion`.

## Performance
- Components memoized where useful.
- SVGs styled via CSS (no re-rasterization).
- Stable shuffle prevents unnecessary remounts.

## Risks / gotchas
- **All art SVG imports should use `?react`** so they’re components, not URLs (fallback warns in dev).
- If an SVG ignores color/width, ensure SVGR/SVGO removed inline `stroke/fill/stroke-width`.

## Rollback plan
Revert this PR; banners return to previous static layout/colors.

## Follow-ups (nice-to-have)
- IO-based text “reveal” animation with reduced-motion respect.
- Default `strokeWidth` map per `tone`.
- Navbar section spy (active link highlight) if not already included.

---

### Checklist
- [x] Mobile: text first; rotated art spans horizontally; no overflow  
- [x] Desktop: alternating sides; paddings feel balanced  
- [x] Dark/light: surfaces + art colors follow tokens  
- [x] SVGs colorize via `text-*`; `strokeWidth` works  
- [x] No console warnings (except dev warning if a string SVG is passed)